### PR TITLE
add Publish to GitHub Container Registry workflow

### DIFF
--- a/.github/workflows/publish_registory.yml
+++ b/.github/workflows/publish_registory.yml
@@ -1,0 +1,23 @@
+name: Publish to GitHub Container Registry
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: build & push to GitHub Container Registry
+        run: |
+          TAG="ghcr.io/${{ github.repository }}:$(date -u '+%Y%m%d%H%M%S')"
+          docker build -t minid:latest -f Dockerfile.minid .
+          cat Dockerfile \
+            | docker run -i --rm minid:latest minid -f - \
+            | docker build --build-arg APT_MIRROR=US --tag "${TAG}" -f - .
+          docker login -u "${{ github.actor }}" -p "${{ secrets.CONTAINER_REGISTRY_TOKEN }}" ghcr.io
+          docker push "${TAG}"
+        env:
+          DOCKER_BUILDKIT: 1

--- a/Dockerfile.minid
+++ b/Dockerfile.minid
@@ -1,2 +1,2 @@
-FROM golang:1.14-stretch
+FROM golang:1.15-buster
 RUN go get -u github.com/orisano/minid


### PR DESCRIPTION
github container registryにpublishするworkflowを追加しました

workflow及びimageを使えるようにするためにいくつか設定をお願いできればと思います
- Settings > Secretsから packages にread/write権限を付与したgithub Personal access tokensを `CONTAINER_REGISTRY_TOKEN` をkeyとして追加
- ビルド完了後、 https://github.com/miyucy?tab=package のrbndパッケージへ遷移→ページ右上にある `package settings` からpublicに設定していただく

※secrets.GITHUB_TOKEN は権限が足りない関係上publisには使えないようです